### PR TITLE
Change default git repository to github

### DIFF
--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -12,7 +12,7 @@ env_dir='./venv'
 gwm_dir='./gwm'
 wheels_dir='./wheels'
 default_branch='develop'
-gwm_address='git://git.osuosl.org/gitolite/ganeti/ganeti_webmgr'
+gwm_address='https://github.com/osuosl/ganeti_webmgr.git'
 
 # helpers: setting text colors
 txtbold=$(tput bold)


### PR DESCRIPTION
We've changed our primary mirror to github, so I figure changing this is a good idea.
